### PR TITLE
Fix #7 issues in the Quantizer.dequantize method

### DIFF
--- a/sinq/quantizer.py
+++ b/sinq/quantizer.py
@@ -315,9 +315,9 @@ class Quantizer:
 
         # 4) Uniform / other paths (unchanged, but robust s2 handling)
         if len(s.shape) == 2:
-            s2_eff = 1 if s2 is None else s2
             W_r = W_r[: s.shape[1 - meta["axis"]]]
-            W_r = ((W_r - z) / s).reshape(meta["shape"]) / s2_eff
+            W_r = ((W_r - z) / s).reshape(meta["shape"]) if s2 is None \
+            else ((W_r - z) * s).reshape(meta["shape"]) * s2
 
         elif len(s.shape) == 3:
             H, W = meta["shape"]


### PR DESCRIPTION
This PR fixes #7 issues in the Quantizer.dequantize method:

1. UnboundLocalError was resolved by properly initializing scale2 and awq_scale.
2. Corrected the dequantization logic for axis=0 cases. Previously, column-wise quantization would result in invalid reshapes and large reconstruction errors.
3. Standard row-wise quantization logic remains intact and backward-compatible.