### PR TITLE
fix: replace bare except with except Exception in cache loading

### DIFF
--- a/tests/eval_my/datautils.py
+++ b/tests/eval_my/datautils.py
@@ -22,7 +22,7 @@ def get_qat_dataset(name, tokenizer, model="llama3", seed="random"):
     if use_cache:
         try:
             return torch.load(cache_file), default_data_collator
-        except:
+        except Exception:
             pass
     if name == "wikitext2":
         data, data_collator = get_wikitext2_train(tokenizer=tokenizer)


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in `datautils.py` cache loading. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.