### PR TITLE
fix: guard meta["packing"] access in Quantizer.dequantize (fixes #25)

### DIFF
--- a/sinq/quantizer.py
+++ b/sinq/quantizer.py
@@ -243,7 +243,7 @@ class Quantizer:
         compute_dtype = meta.get("compute_dtype", torch.float16)
 
         # 1) Unpack to per-element codes
-        if meta["packing"]:
+        if meta.get("packing"):
             if meta.get("view_as_float", False):
                 W_q = W_q.view(meta["unpack_view_dtype"])
             W_r = cls.unpack[meta["packing"]](W_q, dtype=compute_dtype)


### PR DESCRIPTION
# **Title:** fix: guard `meta["packing"]` access in `Quantizer.dequantize` (fixes #25)

## Summary

Fixes [#25](https://github.com/huawei-csl/SINQ/issues/25) — `KeyError: 'packing'` on the first forward after a save/load round-trip of any `nbits=8` quantized model.

Replaces the bracket access at `sinq/quantizer.py:246` with `.get(...)`, matching the defensive pattern already used at every other `"packing"` consumer in the package (`sinqlinear.py:184`, `:298`, `:430`). Also adds a trailing newline at EOF.

## Why this is correct

`SINQLinear.load_state_dict` pops `"packing"` from `meta` whenever the stored tensor's element count already equals the unpacked size — which is *always* true for `nbits=8`, since `N*K*8//8 == N*K`. After the pop, the `if meta["packing"]:` check in `Quantizer.dequantize` raises `KeyError` before control can reach the (correct) `else` branch that handles the unpacked-uint8 path.

The change is semantically equivalent for every state the rest of the codebase already produces:

| State of `"packing"`             | Old behavior              | New behavior              |
| -------------------------------- | ------------------------- | ------------------------- |
| present, truthy (e.g. `"4bit_u8"`) | enters `if` → unpacks   | enters `if` → unpacks ✅  |
| present, `None` (set at `quantizer.py:234` when `bitpack=False`) | skips `if` → uses `else` | skips `if` → uses `else` ✅ |
| absent (popped in `load_state_dict`) | **KeyError** ❌         | skips `if` → uses `else` ✅ |

No call sites need to change — only the missing-key case is repaired.

## Diff

```diff
--- a/sinq/quantizer.py
+++ b/sinq/quantizer.py
@@ -243,7 +243,7 @@ class Quantizer:
         compute_dtype = meta.get("compute_dtype", torch.float16)

         # 1) Unpack to per-element codes
-        if meta["packing"]:
+        if meta.get("packing"):
             if meta.get("view_as_float", False):
                 W_q = W_q.view(meta["unpack_view_dtype"])
             W_r = cls.unpack[meta["packing"]](W_q, dtype=compute_dtype)
```

## Verification

Reproduced the crash with the script in #25 (`google/gemma-4-E4B-it`, `nbits=8`, save → reload → `generate`), applied this patch, and confirmed inference completes with sensible output. The in-memory (no save/load) path was unaffected before the patch and remains unaffected after, as expected — that path never pops `"packing"`.

## Notes / open questions

- Happy to add a regression test that exercises `quantize → save_pretrained → from_pretrained → forward` at `nbits=8` if you'd like — just point me at the preferred test location and I'll push it onto this branch.
- This is a one-line behavioral fix plus an EOF-newline; no public API changes.